### PR TITLE
SerializerPR clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AllowShortLoopsOnASingleLine: false
 #AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
 BinPackParameters: true
-BreakBeforeBinaryOperators: false
+BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Linux
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false

--- a/Common/Utils/include/CommonUtils/BoostSerializer.h
+++ b/Common/Utils/include/CommonUtils/BoostSerializer.h
@@ -68,7 +68,8 @@ class is_boost_serializable
 
 template <typename ContT>
 typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_oarchive>::value
-                        && std::is_class<typename ContT::value_type>::value, std::ostringstream>::type
+                          && std::is_class<typename ContT::value_type>::value,
+                        std::ostringstream>::type
   SerializeContainer(const ContT& dataSet)
 {
   static_assert(check::is_boost_serializable<typename ContT::value_type, boost::archive::binary_oarchive>::value,
@@ -83,7 +84,8 @@ typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::bina
 
 template <typename ContT, typename ContentT = typename ContT::value_type>
 typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_oarchive>::value
-                        && !(std::is_class<ContentT>::value), std::ostringstream>::type
+                          && !(std::is_class<ContentT>::value),
+                        std::ostringstream>::type
   SerializeContainer(const ContT& dataSet)
 {
   static_assert(boost::serialization::is_bitwise_serializable<typename ContT::value_type>::value,
@@ -98,7 +100,8 @@ typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::bina
 
 template <typename ContT>
 typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_iarchive>::value
-                        && std::is_class<typename ContT::value_type>::value, ContT>::type
+                          && std::is_class<typename ContT::value_type>::value,
+                        ContT>::type
   DeserializeContainer(std::string& msgStr)
 {
   static_assert(check::is_boost_serializable<typename ContT::value_type, boost::archive::binary_oarchive>::value,
@@ -113,7 +116,8 @@ typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::bina
 
 template <typename ContT, typename ContentT = typename ContT::value_type>
 typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_iarchive>::value
-                        && !(std::is_class<ContentT>::value), ContT>::type
+                          && !(std::is_class<ContentT>::value),
+                        ContT>::type
   DeserializeContainer(std::string& msgStr)
 {
   static_assert(boost::serialization::is_bitwise_serializable<typename ContT::value_type>::value,


### PR DESCRIPTION
Not sure, how this clang-format config change will affect other code, but your `enable_if`s are much more readable this way compared to a long single line :) (Somehow I have the feeling this might even be a bug in clang-format. Shouldn't it always try to wrap such long lines, independent of the option I changed here? Maybe there is even a better way to solve this).

If you decide to propose this change, you can of course put your name on the commits, just thought, this is the easiest way to explore options on the formatting.